### PR TITLE
support for kylin type VARCHAR(256)

### DIFF
--- a/kylinpy/utils/kylin_types.py
+++ b/kylinpy/utils/kylin_types.py
@@ -36,6 +36,8 @@ KylinType = dict(
 
 def kylin_to_python(_type, s):
     try:
+        if "VARCHAR" in str(_type).upper():
+            _type="VARCHAR"
         return KylinType.get(str(_type).upper())(s) if s else s
     except KeyError:
         logger.error(


### PR DESCRIPTION
This will fix this -  'NoneType' object is not callable error with superset = 0.29.0rc7 issue.