### PR TITLE
fix: bump latest version of sqlalchemy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ build
 *.egg
 *.eggs
 *.egg-info
+*.iml
 .tox
 .cache/
 .idea/

--- a/kylinpy/sqla_dialect.py
+++ b/kylinpy/sqla_dialect.py
@@ -42,11 +42,6 @@ class KylinSQLCompiler(compiler.SQLCompiler):
     def __init__(self, *args, **kwargs):
         super(KylinSQLCompiler, self).__init__(*args, **kwargs)
 
-    def _compose_select_body(self, text, select, inner_columns, froms, byfrom, kwargs):
-        text = super(KylinSQLCompiler, self)._compose_select_body(
-            text, select, inner_columns, froms, byfrom, kwargs)
-        return text
-
     def visit_column(self, *args, **kwargs):
         result = super(KylinSQLCompiler, self).visit_column(*args, **kwargs)
         return result


### PR DESCRIPTION
This PR intends to fix the [issue](https://github.com/Kyligence/kylinpy/issues/48) in the current repo and the [issue](https://github.com/apache/superset/issues/22532) in the Superset repo as well. 

I left comments and reasons for the change in the commit.


### After
![image](https://user-images.githubusercontent.com/2016594/210505461-8a214f48-4d06-4490-87f6-142432cf34f2.png)


### Before
<img width="1121" alt="image" src="https://user-images.githubusercontent.com/2016594/210504385-958138c5-0bd6-4c15-98f9-363e52be2184.png">


