### PR TITLE
chore: release kylinpy 2.8.5

### DIFF
--- a/.github/workflows/python-unit-test-py27.yml
+++ b/.github/workflows/python-unit-test-py27.yml
@@ -1,6 +1,11 @@
 name: Python Unit Test PY27
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
 
 jobs:
   unit-tests-py27:

--- a/.github/workflows/python-unit-test-py3.yml
+++ b/.github/workflows/python-unit-test-py3.yml
@@ -1,6 +1,11 @@
 name: Python Unit Test PY3
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
 
 jobs:
   unit-tests-py3:

--- a/kylinpy/__init__.py
+++ b/kylinpy/__init__.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 
 from .kylinpy import Kylin, create_kylin, KylinCluster, dsn_proxy
 
-__version__ = '0.0.999dev'
+__version__ = '2.8.5'
 
 __all__ = [
     'Kylin', 'create_kylin', 'KylinCluster', 'dsn_proxy',

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ commands =
     python setup.py clean
     rm -rf dist
 deps = twine
-whitelist_externals = rm
+allowlist_externals = rm
 
 [testenv]
 commands = pytest --cov={toxinidir}/kylinpy


### PR DESCRIPTION
Release Kylinpy 2.8.5 to the [PIP](https://pypi.org/project/kylinpy/) repo. Notice that the distribution should use a manually running script which is `./upload-pypi.sh` in the root of the current repo.